### PR TITLE
Fix typos + descriptions

### DIFF
--- a/content/posts/2016-11-09-keeping-multi-user-apps-in-sync-simply/index.md
+++ b/content/posts/2016-11-09-keeping-multi-user-apps-in-sync-simply/index.md
@@ -148,14 +148,17 @@ emit({
   type: 'clickTheButton',
   person: 'Bob'
 })
-// this action as been sent to Hero
+// this action has been sent from Bob to Hero
+```
 ...However, on Sue's computer, this action will be emitted:
 
+
+```
 emit({  
   type: 'clickTheButton',
   person: 'Sue'
 })
-// this action has been sent to Hero
+// this action has been sent from Sue to Hero
 ```
 Hero gets Sue's action first, and then Bob's. Hero sends those actions back to Bob and Sue in order. Bob and Sue both run the actions using their "clickTheButton" mutation, and both Bob and Sue determine Sue to be the winner! Congratulations Sue!
 
@@ -165,6 +168,6 @@ These are the core concepts of sharing a state between multiple people, and it c
 
 Here are some additional things that would make this better:
 
-- It would be easy use the same state and mutations on the server to keep the server's state in sync with the clients. This would be useful for storing backups of the state, or sending the state to a new user.
+- It would be easy to use the same state and mutations on the server to keep the server's state in sync with the clients. This would be useful for storing backups of the state, or sending the state to a new user.
 - Optimistic updates could be implemented by creating a record of un-verified actions that have been emitted, and trusting them up until an official action is received back from the server.
 - Actions can be sent peer-to-peer and used optimistically using the same strategy as above.

--- a/content/posts/2017-10-24-hosting-ghost-with-docker/index.md
+++ b/content/posts/2017-10-24-hosting-ghost-with-docker/index.md
@@ -2,6 +2,7 @@
 title: "Hosting Ghost With Docker"
 date: "2017-10-24T20:05:08-04:00"
 author: "Jacob Grahn"
+description: "Docker is a simple solution for hosting Ghost yourself."
 lastmod: "2020-02-13T19:10:15-05:00"
 ---
 

--- a/content/posts/2017-11-24-faster-multiplayer-with-jiber/index.md
+++ b/content/posts/2017-11-24-faster-multiplayer-with-jiber/index.md
@@ -2,11 +2,11 @@
 title: "Faster Multiplayer with Jiber"
 date: "2017-11-24T15:39:43-05:00"
 author: "Jacob Grahn"
-description: "Just how quickly can friends to shoot each other in the face?"
+description: "Just how quickly can friends shoot each other in the face?"
 lastmod: "2020-02-13T18:42:20-05:00"
 ---
 
-<sup>_Updated 28 Sep 2019: Jiber has been renamed to HiDB._</sup>
+<sup><em>Updated 28 Sep 2019: Jiber has been renamed to HiDB.</em></sup>
 
 # A Starting Point
 Platform Racing 2 is a game I wrote in 2007, and it is still alive and kicking today thanks to a dedicated and generous community of players. It's a multiplayer platformer with many great features, such as shooting your friends in the face with a laser gun. Here's how Platform Racing 2 works that out: (it runs on a multiplayer server called Blossom Server)

--- a/content/posts/2018-01-04-anyone-want-to-work-on-platform-racing/index.md
+++ b/content/posts/2018-01-04-anyone-want-to-work-on-platform-racing/index.md
@@ -2,6 +2,7 @@
 title: "Anyone Want to Work on Platform Racing?"
 author: "Jacob Grahn"
 date: "2018-01-04T23:00:11-05:00"
+description: "Lately I’ve been thinking about how to move forward with the Platform Racing series without abandoning its long history and dedicated community."
 lastmod: "2020-02-13T19:11:26-05:00"
 ---
 


### PR DESCRIPTION
A couple more things:
 - Typos galore! Fixed a bunch
 - Hugo handles blog entries without descriptions by outputting a large part of the article as the description (headings and all with no formatting). In order to prevent that, I've written a simple description for each entry (using language from the entry itself).

(I'll leave you alone, I promise!)